### PR TITLE
Pin zxing-cpp to 2.2.0 until C++20 issues are sorted out

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ opencv-python
 git+https://github.com/wmetcalf/qrdet.git
 git+https://github.com/wmetcalf/QReader.git
 opencv-contrib-python
-zxing-cpp
+zxing-cpp==2.2.0
 fastapi
 uvicorn
 python-magic

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     install_requires=[
         'opencv-python',
         'opencv-contrib-python',
-        'zxing-cpp',
+        'zxing-cpp==2.2.0',
         'fastapi',
         'uvicorn',
         'python-magic',


### PR DESCRIPTION
zxing-cpp 2.3.0 moves to C++20 by default which fails to compile as-is.